### PR TITLE
Make incorrect hotspot reset task on click

### DIFF
--- a/image-hotspot-question.js
+++ b/image-hotspot-question.js
@@ -218,6 +218,8 @@ H5P.ImageHotspotQuestion = (function ($, Question) {
    * @param {Object} hotspot Hotspot parameters.
    */
   ImageHotspotQuestion.prototype.createHotspotFeedback = function ($clickedElement, mouseEvent, hotspot) {
+    const self = this;
+
     // Do not create new hotspot if one exists
     if (this.hotspotFeedback.hotspotChosen) {
       return;
@@ -256,6 +258,11 @@ H5P.ImageHotspotQuestion = (function ($, Question) {
       // Wrong answer, show retry button
       if (this.params.behaviour.enableRetry) {
         this.showButton('retry-button');
+        this.hotspotFeedback.$element.click(function (event) {
+          event.stopPropagation();
+          self.resetTask();
+        });
+
       }
     }
 

--- a/image-hotspot-question.js
+++ b/image-hotspot-question.js
@@ -254,7 +254,8 @@ H5P.ImageHotspotQuestion = (function ($, Question) {
     if (hotspot && hotspot.userSettings.correct) {
       this.hotspotFeedback.$element.addClass('correct');
       this.finishQuestion();
-    } else {
+    }
+    else {
       // Wrong answer, show retry button
       if (this.params.behaviour.enableRetry) {
         this.showButton('retry-button');
@@ -400,7 +401,8 @@ H5P.ImageHotspotQuestion = (function ($, Question) {
     if (parentWidth < naturalWidth) {
       // Scale image down
       neededHeight = parentWidth * imageRatio;
-    } else {
+    }
+    else {
       // Scale image to natural size
       this.$img.width(naturalWidth);
       neededHeight = naturalHeight;


### PR DESCRIPTION
There's a [report of the "x" or "incorrect" hotspot being misleading](https://h5p.org/node/515861).

The changes in this pull request allow to close the hotspot overlay (reset the task) when clicking on the hotspot symbol, too.