### PR TITLE
KL-1473 Add default correct message

### DIFF
--- a/image-hotspot-question.js
+++ b/image-hotspot-question.js
@@ -25,7 +25,8 @@ H5P.ImageHotspotQuestion = (function ($, Question) {
           showFeedbackAsPopup: true,
           l10n: {
             retryText: 'Retry',
-            closeText: 'Close'
+            closeText: 'Close',
+            correctText: 'Correct!'
           }
         }
       },
@@ -260,9 +261,12 @@ H5P.ImageHotspotQuestion = (function ($, Question) {
       }
     }
 
-    var feedbackText = (hotspot && hotspot.userSettings.feedbackText ? hotspot.userSettings.feedbackText : this.params.imageHotspotQuestion.hotspotSettings.noneSelectedFeedback);
-    if (!feedbackText) {
-      feedbackText = '&nbsp;';
+    let feedbackText;
+    if (!hotspot) {
+      feedbackText = this.params.imageHotspotQuestion.hotspotSettings.noneSelectedFeedback || '&nbsp;';
+    }
+    else {
+      feedbackText = hotspot.userSettings.feedbackText || this.params.imageHotspotQuestion.hotspotSettings.l10n.correctText;
     }
 
     // Send these settings into setFeedback to turn feedback into a popup.

--- a/language/.en.json
+++ b/language/.en.json
@@ -61,6 +61,10 @@
                 {
                   "label": "Close button text",
                   "default": "Close"
+                },
+                {
+                  "label": "Default message for correct hotspots",
+                  "default": "Correct!"
                 }
               ]
             }

--- a/language/af.json
+++ b/language/af.json
@@ -61,6 +61,10 @@
                 {
                   "label": "Close button text",
                   "default": "Close"
+                },
+                {
+                  "label": "Default message for correct hotspots",
+                  "default": "Correct!"
                 }
               ]
             }

--- a/language/ar.json
+++ b/language/ar.json
@@ -61,6 +61,10 @@
                 {
                   "label": "نص زر الاغلاق",
                   "default": "Close"
+                },
+                {
+                  "label": "Default message for correct hotspots",
+                  "default": "Correct!"
                 }
               ]
             }

--- a/language/bg.json
+++ b/language/bg.json
@@ -61,6 +61,10 @@
                 {
                   "label": "Текст за бутона за затваряне",
                   "default": "Затвори"
+                },
+                {
+                  "label": "Default message for correct hotspots",
+                  "default": "Correct!"
                 }
               ]
             }

--- a/language/bs.json
+++ b/language/bs.json
@@ -61,6 +61,10 @@
                 {
                   "label": "Close button text",
                   "default": "Close"
+                },
+                {
+                  "label": "Default message for correct hotspots",
+                  "default": "Correct!"
                 }
               ]
             }

--- a/language/ca.json
+++ b/language/ca.json
@@ -61,6 +61,10 @@
                 {
                   "label": "Close button text",
                   "default": "Close"
+                },
+                {
+                  "label": "Default message for correct hotspots",
+                  "default": "Correct!"
                 }
               ]
             }

--- a/language/cs.json
+++ b/language/cs.json
@@ -61,6 +61,10 @@
                 {
                   "label": "Text tlačítka zavřít ",
                   "default": "Zavřít"
+                },
+                {
+                  "label": "Default message for correct hotspots",
+                  "default": "Correct!"
                 }
               ]
             }

--- a/language/da.json
+++ b/language/da.json
@@ -61,6 +61,10 @@
                 {
                   "label": "Close button text",
                   "default": "Close"
+                },
+                {
+                  "label": "Default message for correct hotspots",
+                  "default": "Correct!"
                 }
               ]
             }

--- a/language/de.json
+++ b/language/de.json
@@ -61,6 +61,10 @@
                 {
                   "label": "Beschriftung des \"Schließen\"-Buttons",
                   "default": "Schließen"
+                },
+                {
+                  "label": "Default message for correct hotspots",
+                  "default": "Correct!"
                 }
               ]
             }

--- a/language/el.json
+++ b/language/el.json
@@ -61,6 +61,10 @@
                 {
                   "label": "Ετικέτα κουμπιού κλεισίματος",
                   "default": "Κλείσιμο"
+                },
+                {
+                  "label": "Default message for correct hotspots",
+                  "default": "Correct!"
                 }
               ]
             }

--- a/language/es-mx.json
+++ b/language/es-mx.json
@@ -61,6 +61,10 @@
                 {
                   "label": "Texto del botón Cerrar",
                   "default": "Cerrar"
+                },
+                {
+                  "label": "Default message for correct hotspots",
+                  "default": "Correct!"
                 }
               ]
             }

--- a/language/es.json
+++ b/language/es.json
@@ -61,6 +61,10 @@
                 {
                   "label": "Texto del botón Cerrar",
                   "default": "Cerrar"
+                },
+                {
+                  "label": "Default message for correct hotspots",
+                  "default": "Correct!"
                 }
               ]
             }

--- a/language/et.json
+++ b/language/et.json
@@ -61,6 +61,10 @@
                 {
                   "label": "Sulge nupu tekst",
                   "default": "Sulge"
+                },
+                {
+                  "label": "Default message for correct hotspots",
+                  "default": "Correct!"
                 }
               ]
             }

--- a/language/eu.json
+++ b/language/eu.json
@@ -61,6 +61,10 @@
                 {
                   "label": "Itxi botoiaren testua",
                   "default": "Itxi"
+                },
+                {
+                  "label": "Default message for correct hotspots",
+                  "default": "Correct!"
                 }
               ]
             }

--- a/language/fi.json
+++ b/language/fi.json
@@ -61,6 +61,10 @@
                 {
                   "label": "Sulje painikkeen teksti",
                   "default": "Sulje"
+                },
+                {
+                  "label": "Default message for correct hotspots",
+                  "default": "Correct!"
                 }
               ]
             }

--- a/language/fr.json
+++ b/language/fr.json
@@ -61,6 +61,10 @@
                 {
                   "label": "Texte du bouton Fermer",
                   "default": "Fermer"
+                },
+                {
+                  "label": "Default message for correct hotspots",
+                  "default": "Correct!"
                 }
               ]
             }

--- a/language/he.json
+++ b/language/he.json
@@ -61,6 +61,10 @@
                 {
                   "label": "Close button text",
                   "default": "Close"
+                },
+                {
+                  "label": "Default message for correct hotspots",
+                  "default": "Correct!"
                 }
               ]
             }

--- a/language/hu.json
+++ b/language/hu.json
@@ -61,6 +61,10 @@
                 {
                   "label": "Close button text",
                   "default": "Close"
+                },
+                {
+                  "label": "Default message for correct hotspots",
+                  "default": "Correct!"
                 }
               ]
             }

--- a/language/it.json
+++ b/language/it.json
@@ -61,6 +61,10 @@
                 {
                   "label": "Testo del pulsante \"Chiudi\"",
                   "default": "Chiudi"
+                },
+                {
+                  "label": "Default message for correct hotspots",
+                  "default": "Correct!"
                 }
               ]
             }

--- a/language/ja.json
+++ b/language/ja.json
@@ -61,6 +61,10 @@
                 {
                   "label": "Close button text",
                   "default": "Close"
+                },
+                {
+                  "label": "Default message for correct hotspots",
+                  "default": "Correct!"
                 }
               ]
             }

--- a/language/km.json
+++ b/language/km.json
@@ -61,6 +61,10 @@
                 {
                   "label": "Close button text",
                   "default": "បិទ"
+                },
+                {
+                  "label": "Default message for correct hotspots",
+                  "default": "Correct!"
                 }
               ]
             }

--- a/language/ko.json
+++ b/language/ko.json
@@ -61,6 +61,10 @@
                 {
                   "label": "Close button text",
                   "default": "Close"
+                },
+                {
+                  "label": "Default message for correct hotspots",
+                  "default": "Correct!"
                 }
               ]
             }

--- a/language/nb.json
+++ b/language/nb.json
@@ -61,6 +61,10 @@
                 {
                   "label": "Close button text",
                   "default": "Close"
+                },
+                {
+                  "label": "Default message for correct hotspots",
+                  "default": "Correct!"
                 }
               ]
             }

--- a/language/nl.json
+++ b/language/nl.json
@@ -61,6 +61,10 @@
                 {
                   "label": "Tekst sluit-knop",
                   "default": "Sluit"
+                },
+                {
+                  "label": "Default message for correct hotspots",
+                  "default": "Correct!"
                 }
               ]
             }

--- a/language/nn.json
+++ b/language/nn.json
@@ -61,6 +61,10 @@
                 {
                   "label": "Close button text",
                   "default": "Lukk"
+                },
+                {
+                  "label": "Default message for correct hotspots",
+                  "default": "Correct!"
                 }
               ]
             }

--- a/language/pl.json
+++ b/language/pl.json
@@ -61,6 +61,10 @@
                 {
                   "label": "Close button text",
                   "default": "Close"
+                },
+                {
+                  "label": "Default message for correct hotspots",
+                  "default": "Correct!"
                 }
               ]
             }

--- a/language/pt-br.json
+++ b/language/pt-br.json
@@ -61,6 +61,10 @@
                 {
                   "label": "Texto do botão Fechar",
                   "default": "Fechar"
+                },
+                {
+                  "label": "Default message for correct hotspots",
+                  "default": "Correct!"
                 }
               ]
             }

--- a/language/pt.json
+++ b/language/pt.json
@@ -61,6 +61,10 @@
                 {
                   "label": "Texto do botão de fechar",
                   "default": "Fechar"
+                },
+                {
+                  "label": "Default message for correct hotspots",
+                  "default": "Correct!"
                 }
               ]
             }

--- a/language/ro.json
+++ b/language/ro.json
@@ -61,6 +61,10 @@
                 {
                   "label": "Close button text",
                   "default": "Close"
+                },
+                {
+                  "label": "Default message for correct hotspots",
+                  "default": "Correct!"
                 }
               ]
             }

--- a/language/ru.json
+++ b/language/ru.json
@@ -61,6 +61,10 @@
                 {
                   "label": "Текст кнопки закрытия",
                   "default": "Закрыть"
+                },
+                {
+                  "label": "Default message for correct hotspots",
+                  "default": "Correct!"
                 }
               ]
             }

--- a/language/sma.json
+++ b/language/sma.json
@@ -61,6 +61,10 @@
                 {
                   "label": "Close button text",
                   "default": "Close"
+                },
+                {
+                  "label": "Default message for correct hotspots",
+                  "default": "Correct!"
                 }
               ]
             }

--- a/language/sme.json
+++ b/language/sme.json
@@ -61,6 +61,10 @@
                 {
                   "label": "Close button text",
                   "default": "Close"
+                },
+                {
+                  "label": "Default message for correct hotspots",
+                  "default": "Correct!"
                 }
               ]
             }

--- a/language/smj.json
+++ b/language/smj.json
@@ -61,6 +61,10 @@
                 {
                   "label": "Close button text",
                   "default": "Close"
+                },
+                {
+                  "label": "Default message for correct hotspots",
+                  "default": "Correct!"
                 }
               ]
             }

--- a/language/sr.json
+++ b/language/sr.json
@@ -61,6 +61,10 @@
                 {
                   "label": "Close button text",
                   "default": "Close"
+                },
+                {
+                  "label": "Default message for correct hotspots",
+                  "default": "Correct!"
                 }
               ]
             }

--- a/language/sv.json
+++ b/language/sv.json
@@ -61,6 +61,10 @@
                 {
                   "label": "Close button text",
                   "default": "Close"
+                },
+                {
+                  "label": "Default message for correct hotspots",
+                  "default": "Correct!"
                 }
               ]
             }

--- a/language/tr.json
+++ b/language/tr.json
@@ -61,6 +61,10 @@
                 {
                   "label": "Close button text",
                   "default": "Close"
+                },
+                {
+                  "label": "Default message for correct hotspots",
+                  "default": "Correct!"
                 }
               ]
             }

--- a/language/vi.json
+++ b/language/vi.json
@@ -61,6 +61,10 @@
                 {
                   "label": "Close button text",
                   "default": "Close"
+                },
+                {
+                  "label": "Default message for correct hotspots",
+                  "default": "Correct!"
                 }
               ]
             }

--- a/language/zh-hans.json
+++ b/language/zh-hans.json
@@ -61,6 +61,10 @@
                 {
                   "label": "关闭功能钮名称",
                   "default": "关闭"
+                },
+                {
+                  "label": "Default message for correct hotspots",
+                  "default": "Correct!"
                 }
               ]
             }

--- a/language/zh-tw.json
+++ b/language/zh-tw.json
@@ -61,6 +61,10 @@
                 {
                   "label": "關閉功能鈕名稱",
                   "default": "關閉"
+                },
+                {
+                  "label": "Default message for correct hotspots",
+                  "default": "Correct!"
                 }
               ]
             }

--- a/semantics.json
+++ b/semantics.json
@@ -140,6 +140,13 @@
                 "type": "text",
                 "default": "Close",
                 "optional": true
+              },
+              {
+                "name": "correctText",
+                "label": "Default message for correct hotspots",
+                "type": "text",
+                "default": "Correct!",
+                "optional": true
               }
             ]
           }


### PR DESCRIPTION
When there was no message set for finding the correct hotspot, the default message for wrong hotspots was used. In consequence, the user could find the correct hotspot, see the green check mark, but receive the message for a wrong hotspot.

When merged in, there'll be a default message for correct hotspots (configurable in the editor) that will be used for correct hotspots if no special feedback was set by the author.