### PR TITLE
JI-3263 Fix xAPI results not being added

### DIFF
--- a/image-hotspot-question.js
+++ b/image-hotspot-question.js
@@ -353,6 +353,12 @@ H5P.ImageHotspotQuestion = (function ($, Question) {
   ImageHotspotQuestion.prototype.triggerAnswered = function () {
     var self = this;
     var xAPIEvent = self.createXAPIEventTemplate('answered');
+
+    // Add score to xAPIEvent
+    const score = self.getScore();
+    const maxScore = self.getMaxScore();
+    xAPIEvent.setScoredResult(score, maxScore, self, true, score === maxScore);
+
     self.addQuestionToXAPI(xAPIEvent);
     self.trigger(xAPIEvent);
   };


### PR DESCRIPTION
During JI-3263 setting the score for the xAPI `answered` statement was removed (still present in `getXAPIData()` though), probably not intentionally.

When merged in, this change will add back the results to the xAPI `answered` statement.